### PR TITLE
Fix false positive warning with generics

### DIFF
--- a/src/main/java/org/checkerframework/checker/returnsrcvr/qual/MaybeThis.java
+++ b/src/main/java/org/checkerframework/checker/returnsrcvr/qual/MaybeThis.java
@@ -9,6 +9,7 @@ import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.LiteralKind;
 import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TypeUseLocation;
 
 /** The top type for the TemplateFora Checker's type system. */
 @Retention(RetentionPolicy.RUNTIME)
@@ -16,5 +17,5 @@ import org.checkerframework.framework.qual.SubtypeOf;
 @DefaultQualifierInHierarchy
 @SubtypeOf({})
 @QualifierForLiterals(LiteralKind.NULL)
-@DefaultFor(types = Void.class)
+@DefaultFor(types = Void.class, value = TypeUseLocation.LOWER_BOUND)
 public @interface MaybeThis {}

--- a/tests/returnsrcvr/NullsAndGenerics.java
+++ b/tests/returnsrcvr/NullsAndGenerics.java
@@ -1,0 +1,29 @@
+import java.util.Map;
+
+public class NullsAndGenerics<E> {
+
+    private boolean enableProtoAnnotations;
+
+    @SuppressWarnings("unchecked")
+    private <T, O extends Message, E extends ProtoElement> T getProtoExtension(
+            E element, GeneratedExtension<O, T> extension) {
+        // Use this method as the chokepoint for all field annotations processing, so we can
+        // toggle on/off annotations processing in one place.
+        if (!enableProtoAnnotations) {
+            return null;
+        }
+        return (T) element.getOptionFields().get(extension.getDescriptor());
+    }
+
+    // stubs of relevant classes
+    private class Message {}
+    private class ProtoElement {
+        public Map<FieldDescriptor, Object> getOptionFields() { return null; }
+    }
+    private class FieldDescriptor {}
+    private class GeneratedExtension<O, T> {
+        public FieldDescriptor getDescriptor() {
+            return null;
+        }
+    }
+}

--- a/tests/returnsrcvr/SimpleTest.java
+++ b/tests/returnsrcvr/SimpleTest.java
@@ -43,6 +43,7 @@ class SimpleTest {
         @This SimpleTest x = new SimpleTest();
 
         // :: error: invalid.this.location
+        // :: error: type.argument.type.incompatible
         java.util.List<@This String> l = null;
     }
 


### PR DESCRIPTION
We need to default the lower bound of generic type variables to `TOP` to handle cases like a method with generic return type that returns `null` (whose default type is `TOP`).