### PR TITLE
Don't rely on trees being present when finding builder setter methods

### DIFF
--- a/tests/autovalue/Animal.java
+++ b/tests/autovalue/Animal.java
@@ -1,9 +1,16 @@
-import org.checkerframework.checker.returnsrcvr.qual.*;
 import com.google.auto.value.AutoValue;
+import org.checkerframework.checker.nullness.qual.*;
 
+/**
+ * Adapted from the standard AutoValue example code:
+ * https://github.com/google/auto/blob/master/value/userguide/builders.md
+ */
 @AutoValue
 abstract class Animal {
   abstract String name();
+
+  abstract @Nullable String habitat();
+
   abstract int numberOfLegs();
 
   static Builder builder() {
@@ -12,8 +19,42 @@ abstract class Animal {
 
   @AutoValue.Builder
   abstract static class Builder {
+
     abstract Builder setName(String value);
+
     abstract Builder setNumberOfLegs(int value);
+
+    abstract Builder setHabitat(String value);
+
     abstract Animal build();
+  }
+
+  public static void buildSomethingWrong() {
+    Builder b = builder();
+    b.setName("Frank");
+    b.build();
+  }
+
+  public static void buildSomethingRight() {
+    Builder b = builder();
+    b.setName("Frank");
+    b.setNumberOfLegs(4);
+    b.build();
+  }
+
+  public static void buildSomethingRightIncludeOptional() {
+    Builder b = builder();
+    b.setName("Frank");
+    b.setNumberOfLegs(4);
+    b.setHabitat("jungle");
+    b.build();
+  }
+
+  public static void buildSomethingWrongFluent() {
+    builder().setName("Frank").build();
+  }
+
+  public static void buildSomethingRightFluent() {
+    builder().setName("Jim").setNumberOfLegs(7).build();
   }
 }


### PR DESCRIPTION
When processing AutoValue-generated code, it turns out that the ASTs for the original source code with AutoValue annotations may no longer be present (??).  So, rewrite our code for detecting builder setters to not rely on trees being present; just use `Element`s instead.

Also update the `Animal.java` test with uses of the AutoValue types.  Apparently without that, code does not get generated, so this bug was not exposed.