### PR TITLE
Add separate qual artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,15 +34,31 @@ tasks.withType(JavaCompile).all {
     options.compilerArgs.add("-Xlint:all")
 }
 
+def rrVersion = '0.1-SNAPSHOT'
+
+task qualJar(type: Jar) {
+    baseName 'returnsrcvr-qual'
+    from (sourceSets.main.output) {
+        include "**/qual/**"
+    }
+}
+
 // Run `./gradlew publishToMavenLocal` to publish your checker to your local Maven repository.
 publishing {
     publications {
-        maven(MavenPublication) {
+        checker(MavenPublication) {
             groupId = 'org.checkerframework'
             artifactId = 'returnsrcvr-checker'
-            version = '0.1-SNAPSHOT'
+            version = "${rrVersion}"
 
             from components.java
+        }
+
+        qual(MavenPublication) {
+            groupId = 'org.checkerframework'
+            artifactId = 'returnsrcvr-qual'
+            version = "${rrVersion}"
+            artifact qualJar
         }
     }
 }


### PR DESCRIPTION
This adds a separate artifact containing only the type annotations defined by the checker, following the same design style as the `checker.jar` vs `checker-qual.jar` difference in the main Checker Framework.

A separate artifact is needed because the annotations need to be on the actual classpath when compiling the program, but the checker (and its heavy-weight dependency on the Checker Framework) does not.

A forthcoming pull request to the Typesafe Builder Checker will do the same there.