### PR TITLE
Respect lombok.Generated annotations on methods, too

### DIFF
--- a/returnsrcvr-checker/src/main/java/org/checkerframework/checker/returnsrcvr/ReturnsRcvrAnnotatedTypeFactory.java
+++ b/returnsrcvr-checker/src/main/java/org/checkerframework/checker/returnsrcvr/ReturnsRcvrAnnotatedTypeFactory.java
@@ -79,7 +79,8 @@ public class ReturnsRcvrAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
       boolean inAutoValueBuilder = hasAnnotation(enclosingElement, AutoValue.Builder.class);
       boolean inLombokBuilder =
-          hasAnnotationByName(enclosingElement, "lombok.Generated")
+          (hasAnnotationByName(enclosingElement, "lombok.Generated")
+                  || hasAnnotationByName(element, "lombok.Generated"))
               && enclosingElement.getSimpleName().toString().endsWith("Builder");
 
       if (!inAutoValueBuilder && !inLombokBuilder) {


### PR DESCRIPTION
This is the analogue of [kelloggm/object-construction-checker#57](https://github.com/kelloggm/object-construction-checker/pull/57), done for the same reason.